### PR TITLE
Don't update chrome webstore if a micro version is published.

### DIFF
--- a/.github/workflows/updatewebstore.yml
+++ b/.github/workflows/updatewebstore.yml
@@ -24,3 +24,8 @@ jobs:
       
       - name: Run uploader file
         run: python .github/workflows/webstore.py
+        env:
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          GH_AUTH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}

--- a/.github/workflows/updatewebstore.yml
+++ b/.github/workflows/updatewebstore.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: 3.8
 
       - name: Install dependencies
-        run: pip install requests
+        run: pip install requests packaging
       
       - name: Run uploader file
         run: python .github/workflows/webstore.py


### PR DESCRIPTION
Only attempts to publish to the chrome webstore if a major or minor version change is detected (not anything less).
Also adds the GitHub secrets to env because apparently GitHub doesn't do that automatically.